### PR TITLE
ci: update to Node.js 24 compatible action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   # -----------------------------------------------------------------------
   # Job 1: Test
@@ -20,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
 
@@ -68,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
 


### PR DESCRIPTION
- setup-dotnet@v3 → setup-dotnet@v4 (both test and publish jobs)
- Added FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true at workflow level to opt into Node.js 24 for checkout@v4 and upload-artifact@v4, which do not yet have newer major versions available

Addresses deprecation warnings ahead of the June 2026 enforcement date.