### PR TITLE
test: wire Testcontainers for integration tests, remove cloud dependency

### DIFF
--- a/tests/CosmoBase.Tests/CosmoBase.Tests.csproj
+++ b/tests/CosmoBase.Tests/CosmoBase.Tests.csproj
@@ -36,14 +36,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Configuration\appsettings.json">
+    <!-- Required: base test configuration (emulator settings, model configs, logging) -->
+    <Content Include="Configuration\appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="localsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <!-- Optional: gitignored local override for testing against a real Cosmos endpoint -->
+    <None Update="localsettings.json" Condition="Exists('localsettings.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tests/CosmoBase.Tests/Fixtures/CosmoBaseTestFixture.cs
+++ b/tests/CosmoBase.Tests/Fixtures/CosmoBaseTestFixture.cs
@@ -1,24 +1,33 @@
-using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using CosmoBase.Abstractions.Configuration;
 using CosmoBase.Abstractions.Interfaces;
 using CosmoBase.DependencyInjection;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using Testcontainers.CosmosDb;
 using Xunit.Abstractions;
 
 namespace CosmoBase.Tests.Fixtures;
 
 /// <summary>
-/// Test fixture for CosmoBase integration tests with real Cosmos DB emulator
+/// Shared test fixture for CosmoBase integration tests.
+///
+/// Connection strategy (in priority order):
+///   1. localsettings.json present → use its connection string (local emulator or cloud Cosmos).
+///      This file is gitignored and only exists on a developer's machine by choice.
+///   2. No localsettings.json → spin up a Cosmos emulator via Testcontainers (Docker required).
+///      This is the path taken on GitHub Actions and on fresh clones.
 /// </summary>
 public class CosmoBaseTestFixture : IAsyncLifetime, IDisposable
 {
     private ServiceProvider? _serviceProvider;
     private readonly IConfiguration _configuration;
     private CosmosClient? _cosmosClient;
+    private CosmosDbContainer? _container;
 
     public IServiceProvider ServiceProvider => _serviceProvider ??
                                                throw new InvalidOperationException(
@@ -26,15 +35,90 @@ public class CosmoBaseTestFixture : IAsyncLifetime, IDisposable
 
     public CosmoBaseTestFixture()
     {
-        var builder = new ConfigurationBuilder()
+        _configuration = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
-            // Use app settings
-            .AddJsonFile("Configuration/appsettings.json", optional: true, reloadOnChange: true)
-            // Override with local settings (if you want to use your own CosmosDb in Azure, etc.)
-            .AddJsonFile("localsettings.json", optional: true, reloadOnChange: true);
+            .AddJsonFile("Configuration/appsettings.json", optional: false, reloadOnChange: false)
+            .AddJsonFile("localsettings.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .Build();
+    }
 
+    public async Task InitializeAsync()
+    {
+        string connectionString;
 
-        _configuration = builder.Build();
+        var localSettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "localsettings.json");
+        var useTestcontainers = !File.Exists(localSettingsPath);
+
+        if (useTestcontainers)
+        {
+            // No local override — start the Cosmos emulator in a container.
+            // Works on GitHub Actions (Docker available on ubuntu-latest) and locally with Docker Desktop.
+            _container = new CosmosDbBuilder().Build();
+            await _container.StartAsync();
+            connectionString = _container.GetConnectionString();
+        }
+        else
+        {
+            connectionString = _configuration["CosmoBase:CosmosClientConfigurations:0:ConnectionString"]
+                ?? throw new InvalidOperationException(
+                    "localsettings.json is present but has no connection string at " +
+                    "CosmoBase:CosmosClientConfigurations:0:ConnectionString.");
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddConsole());
+        services.AddSingleton(_configuration);
+
+        // Register CosmoBase using config for model/logging settings, but override
+        // the connection string with the runtime value resolved above.
+        services.AddCosmoBase(_configuration, new TestUserContext("TestUser"), options =>
+        {
+            options.CosmosClientConfigurations = options.CosmosClientConfigurations
+                .Select(c => c with { ConnectionString = connectionString })
+                .ToList();
+        });
+
+        if (useTestcontainers)
+        {
+            // The Cosmos emulator in Testcontainers uses a self-signed TLS certificate.
+            // Override the CosmosClient dictionary registered by AddCosmoBase with a
+            // client configured to accept it. In .NET DI the last registration wins for
+            // single-service resolution, so this replaces the internal registration.
+            var clientName = _configuration["CosmoBase:CosmosClientConfigurations:0:Name"] ?? "TestPrimary";
+
+            services.AddSingleton<IReadOnlyDictionary<string, CosmosClient>>(_ =>
+                new Dictionary<string, CosmosClient>
+                {
+                    [clientName] = new CosmosClient(
+                        connectionString,
+                        new CosmosClientOptions
+                        {
+                            // Accept the emulator's self-signed certificate — test use only.
+                            HttpClientFactory = () => new HttpClient(
+                                new HttpClientHandler
+                                {
+                                    ServerCertificateCustomValidationCallback =
+                                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                                }),
+                            ConnectionMode = ConnectionMode.Gateway,
+                            AllowBulkExecution = true,
+                            MaxRetryAttemptsOnRateLimitedRequests = 3,
+                            MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(10),
+                            UseSystemTextJsonSerializerWithOptions = new JsonSerializerOptions
+                            {
+                                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                            }
+                        })
+                });
+        }
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        var cosmosClients = _serviceProvider.GetRequiredService<IReadOnlyDictionary<string, CosmosClient>>();
+        _cosmosClient = cosmosClients.Values.First();
+
+        await EnsureTestDatabaseAsync();
     }
 
     public async Task DisposeAsync()
@@ -46,6 +130,12 @@ public class CosmoBaseTestFixture : IAsyncLifetime, IDisposable
         }
 
         _cosmosClient?.Dispose();
+
+        if (_container != null)
+        {
+            await _container.StopAsync();
+            await _container.DisposeAsync();
+        }
     }
 
     public void Dispose()
@@ -55,56 +145,24 @@ public class CosmoBaseTestFixture : IAsyncLifetime, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public async Task InitializeAsync()
-    {
-        var services = new ServiceCollection();
-
-        // Add logging with console output
-        services.AddLogging(builder => { builder.AddConsole(); });
-
-        // Add configuration
-        services.AddSingleton(_configuration);
-
-        // Create test user context
-        var testUserContext = new TestUserContext("TestUser");
-
-        // Add CosmoBase with test configuration
-        services.AddCosmoBase(_configuration, testUserContext);
-
-        // Build service provider
-        _serviceProvider = services.BuildServiceProvider();
-        var cfg = _serviceProvider.GetRequiredService<IOptions<CosmosConfiguration>>().Value;
-
-        var cosmosClients = _serviceProvider.GetRequiredService<IReadOnlyDictionary<string, CosmosClient>>();
-
-        // Create direct Cosmos client for setup/cleanup
-        _cosmosClient = cosmosClients.Values.First();
-
-        // Ensure test database exists
-        await EnsureTestDatabaseAsync();
-    }
-
     private async Task EnsureTestDatabaseAsync()
     {
         try
         {
             if (_cosmosClient == null) return;
 
-            // Create test database
             var cfg = _serviceProvider!.GetRequiredService<IOptions<CosmosConfiguration>>().Value;
             var database = await _cosmosClient.CreateDatabaseIfNotExistsAsync("CosmoBaseTestDb");
 
-            // Create containers based on model configurations
             foreach (var modelConfig in cfg.CosmosModelConfigurations)
             {
-                var partitionKeyPath = $"/{modelConfig.PartitionKey}";
                 await database.Database.CreateContainerIfNotExistsAsync(
                     modelConfig.CollectionName,
-                    partitionKeyPath);
+                    $"/{modelConfig.PartitionKey}");
             }
 
-            var logger = _serviceProvider?.GetService<ILogger<CosmoBaseTestFixture>>();
-            logger?.LogInformation("Test database and containers created successfully");
+            var logger = _serviceProvider.GetService<ILogger<CosmoBaseTestFixture>>();
+            logger?.LogInformation("Test database and containers ready");
         }
         catch (Exception ex)
         {
@@ -117,89 +175,45 @@ public class CosmoBaseTestFixture : IAsyncLifetime, IDisposable
     private async Task CleanupTestDataAsync()
     {
         var cleanupEnabled = _configuration.GetSection("TestSettings")["DatabaseCleanupEnabled"];
-        if (bool.Parse(cleanupEnabled ?? "true"))
+        if (!bool.TryParse(cleanupEnabled, out var enabled) || enabled)
         {
             try
             {
                 if (_cosmosClient == null) return;
-
-                // Delete test database (this removes all data)
                 await _cosmosClient.GetDatabase("CosmoBaseTestDb").DeleteAsync();
 
                 var logger = _serviceProvider?.GetService<ILogger<CosmoBaseTestFixture>>();
-                logger?.LogInformation("Test database cleaned up successfully");
+                logger?.LogInformation("Test database cleaned up");
             }
             catch (Exception ex)
             {
-                // Log cleanup errors but don't fail the test
                 var logger = _serviceProvider?.GetService<ILogger<CosmoBaseTestFixture>>();
-                logger?.LogWarning(ex, "Failed to cleanup test data");
+                logger?.LogWarning(ex, "Failed to cleanup test data (non-fatal)");
             }
         }
     }
 
-    public T GetRequiredService<T>() where T : class
-    {
-        return ServiceProvider.GetRequiredService<T>();
-    }
-
-    public T? GetService<T>()
-    {
-        return ServiceProvider.GetService<T>();
-    }
-
-    /// <summary>
-    /// Get a fresh test database name for isolated tests
-    /// </summary>
+    public T GetRequiredService<T>() where T : class => ServiceProvider.GetRequiredService<T>();
+    public T? GetService<T>() => ServiceProvider.GetService<T>();
     public string GetTestDatabaseName() => $"CosmoBaseTestDb_{Guid.NewGuid():N}";
 }
 
-/// <summary>
-/// Test user context for audit field testing
-/// </summary>
+/// <summary>Test user context for audit field verification.</summary>
 public class TestUserContext(string userId) : IUserContext
 {
     public string? GetCurrentUser() => userId;
 }
 
-/// <summary>
-/// XUnit logger provider for test output - use per-test method
-/// </summary>
-public class XunitLoggerProvider : ILoggerProvider
+/// <summary>Routes xUnit test output to ILogger.</summary>
+public class XunitLoggerProvider(ITestOutputHelper output) : ILoggerProvider
 {
-    private readonly ITestOutputHelper _testOutputHelper;
-
-    public XunitLoggerProvider(ITestOutputHelper testOutputHelper)
-    {
-        _testOutputHelper = testOutputHelper;
-    }
-
-    public ILogger CreateLogger(string categoryName)
-    {
-        return new XunitLogger(_testOutputHelper, categoryName);
-    }
-
-    public void Dispose()
-    {
-    }
+    public ILogger CreateLogger(string categoryName) => new XunitLogger(output, categoryName);
+    public void Dispose() { }
 }
 
-/// <summary>
-/// XUnit logger implementation - use per-test method
-/// </summary>
-public class XunitLogger : ILogger
+public class XunitLogger(ITestOutputHelper output, string category) : ILogger
 {
-    private readonly ITestOutputHelper _testOutputHelper;
-    private readonly string _categoryName;
-
-    public XunitLogger(ITestOutputHelper testOutputHelper, string categoryName)
-    {
-        _testOutputHelper = testOutputHelper;
-        _categoryName = categoryName;
-    }
-
     public IDisposable BeginScope<TState>(TState state) where TState : notnull => new NoOpDisposable();
-
     public bool IsEnabled(LogLevel logLevel) => true;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
@@ -207,24 +221,15 @@ public class XunitLogger : ILogger
     {
         try
         {
-            var message = formatter(state, exception);
-            _testOutputHelper.WriteLine($"[{logLevel}] {_categoryName}: {message}");
-
+            output.WriteLine($"[{logLevel}] {category}: {formatter(state, exception)}");
             if (exception != null)
-            {
-                _testOutputHelper.WriteLine($"Exception: {exception}");
-            }
+                output.WriteLine($"Exception: {exception}");
         }
         catch
         {
-            // Ignore logging failures in tests
+            // Swallow: xUnit throws if output is written after the test completes
         }
     }
 
-    private class NoOpDisposable : IDisposable
-    {
-        public void Dispose()
-        {
-        }
-    }
+    private sealed class NoOpDisposable : IDisposable { public void Dispose() { } }
 }


### PR DESCRIPTION
The fixture previously relied on a connection string from localsettings.json (gitignored), which meant integration tests could never run on GitHub Actions or a fresh clone without manually creating that file.

Changes:
- CosmoBase.Tests.csproj: add Configuration/appsettings.json to Content with CopyToOutputDirectory so it is always present in the output directory; remove the duplicate localsettings.json ItemGroup entries
- CosmoBaseTestFixture: spin up a CosmosDbContainer via Testcontainers when localsettings.json is absent (CI, fresh clones); use localsettings.json when present (local developer override for cloud/emulator testing)
- Override the CosmosClient DI registration with a Gateway-mode client that accepts the emulator's self-signed TLS certificate (DangerousAcceptAny...) — scoped to the Testcontainers path only
- Config builder now adds AddEnvironmentVariables() and marks appsettings.json as required (optional: false)

GitHub Actions runners (ubuntu-latest) have Docker available, so Testcontainers works in CI without any additional workflow changes.