### PR TITLE
fix: resolve partition key regressions from v0.1.x behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ CosmoBase uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.0.2] — 2026-05-27
+
+### Fixed
+
+- **Partition key property no longer required on read-only DAO models.** Prior to this release,
+  registering a DAO that omitted the partition key property caused a startup failure (repository
+  constructor threw `ArgumentException` from `Expression.Property`). Read-only summary/projection
+  models — which never perform writes and therefore never need to extract a partition key value
+  from an instance — now register and query without error. Write operations still enforce the
+  requirement and throw `CosmosConfigurationException` with a clear actionable message.
+
+- **`PartitionKey` configuration now accepts the Cosmos JSON field name.** Previously, the value
+  in `appsettings.json` had to exactly match the C# property name on the DAO class. If the
+  property was decorated with `[JsonPropertyName("btLockboxNumber")]` (C# name `Lockbox`), the
+  config required `"Lockbox"`, not `"btLockboxNumber"`, which was inconsistent with how Cosmos DB
+  stores and queries the field. Both `BuildPartitionKeyAccessor` (repository) and
+  `GetPartitionKeyValue` (validator) now perform a two-step lookup: C# property name first, then
+  a scan for a `[JsonPropertyName]` attribute match. SQL queries continue to use the configured
+  value as-is (already the correct Cosmos JSON path).
+
+### Added
+
+- **`ICosmosRepository<T>.PartitionKeyProperty`** — new read-only property exposing the
+  configured partition key name. Used by `CosmosDataWriteService` for construction-time
+  validation; also available to callers who need to inspect the configuration at runtime.
+
+- **Write-service construction-time validation.** `CosmosDataWriteService<TDto, TDao>` now
+  validates at construction that `TDao` exposes the configured partition key property (by C#
+  name or `[JsonPropertyName]`). This preserves fail-fast semantics for write models:
+  misconfiguration surfaces on the first DI scope resolution rather than on the first actual
+  write call.
+
+---
+
 ## [1.0.1] — 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ In `appsettings.json`:
 
 > **Common pitfalls:**
 > - `ModelName` must match the DAO class name exactly — `"ProductDao"`, not `"Product"`
-> - `PartitionKey` is the property name on your DAO class — `"Category"`, not `"/category"`
+> - `PartitionKey` accepts either the **Cosmos JSON field name** or the **C# property name**. If your DAO uses `[JsonPropertyName("btLockboxNumber")] public string? Lockbox { get; set; }`, you may use either `"btLockboxNumber"` or `"Lockbox"` in config — both resolve correctly. Do **not** include the leading `/` (e.g. `"Category"`, not `"/category"`).
+> - Read-only summary models that aggregate across a collection do not need to include the partition key property — omit it freely and CosmoBase will not require it at startup or query time.
 
 ---
 

--- a/src/CosmoBase.Abstractions/Interfaces/ICosmosRepository.cs
+++ b/src/CosmoBase.Abstractions/Interfaces/ICosmosRepository.cs
@@ -29,6 +29,12 @@ public interface ICosmosRepository<T>
     where T : class, ICosmosDataModel
 {
     /// <summary>
+    /// The partition key property name as configured (Cosmos JSON field name or C# property name).
+    /// Used by write services to validate at construction time that the DAO type is write-capable.
+    /// </summary>
+    string PartitionKeyProperty { get; }
+
+    /// <summary>
     /// Exposes an <see cref="IQueryable"/> over the container for custom LINQ queries.
     /// </summary>
     IQueryable<T> Queryable { get; }

--- a/src/CosmoBase.Core/Repositories/CosmosRepository.cs
+++ b/src/CosmoBase.Core/Repositories/CosmosRepository.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Net;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 using CosmoBase.Abstractions.Configuration;
 using CosmoBase.Abstractions.Enums;
 using CosmoBase.Abstractions.Exceptions;
@@ -34,19 +36,14 @@ public class CosmosRepository<T> : ICosmosRepository<T> where T : class, ICosmos
     private readonly IAuditFieldManager<T> _auditFieldManager;
 
     // Compiled delegate that reads the partition-key property from a T instance.
+    // Null when the DAO type does not expose the partition key property — valid for
+    // read-only models.  Write operations call GetPartitionKeyValue(), which throws
+    // a clear error if the delegate is null, so misconfigured write models are caught
+    // at the first write call rather than silently at query time.
     //
-    // Why a compiled expression instead of typeof(T).GetProperty(...).GetValue(...)?
-    // GetProperty() does a dictionary lookup in the type's metadata on every call.
-    // GetValue() boxes the result and dispatches through the reflection invoke path.
-    // Both costs add up when CreateAsync / ReplaceAsync / UpsertAsync are called at
-    // high throughput.
-    //
-    // Expression.Lambda<Func<T, string>>(...).Compile() emits a real CLR method once
-    // at construction time.  Every subsequent call is a direct property read — the same
-    // cost as writing `item.Category` in source code — with no reflection overhead at
-    // all.  The delegate is stored in a readonly field so it is thread-safe by
-    // construction and shared across all calls on this repository instance.
-    private readonly Func<T, string> _getPartitionKey;
+    // The delegate is compiled once at construction from an expression tree, so every
+    // subsequent call is a direct property read with no reflection overhead.
+    private readonly Func<T, string>? _getPartitionKey;
 
     /// <summary>
     /// Initializes a new instance using <paramref name="configuration"/> to locate containers and <paramref name="cosmosClients"/> for database access.
@@ -102,11 +99,14 @@ public class CosmosRepository<T> : ICosmosRepository<T> where T : class, ICosmos
         _writeContainer = _writeClient
             .GetContainer(modelConfig.DatabaseName, modelConfig.CollectionName);
 
-        // Build the compiled partition-key accessor now that _partitionKeyProperty is known.
-        // Fail fast here (constructor) rather than on the first write so misconfigured
-        // model names surface at startup rather than at runtime.
+        // Build the compiled accessor. Returns null when the DAO type does not expose the
+        // partition key property — this is valid for read-only models.  Write operations
+        // (CreateAsync, ReplaceAsync, etc.) call GetPartitionKeyValue(), which throws if null.
         _getPartitionKey = BuildPartitionKeyAccessor(_partitionKeyProperty);
     }
+
+    /// <inheritdoc/>
+    public string PartitionKeyProperty => _partitionKeyProperty;
 
     /// <inheritdoc/>
     public IQueryable<T> Queryable => _readContainer.GetItemLinqQueryable<T>(true);
@@ -920,11 +920,19 @@ public class CosmosRepository<T> : ICosmosRepository<T> where T : class, ICosmos
     }
 
     /// <summary>
-    /// Returns the partition-key value for <paramref name="item"/> using the pre-compiled
-    /// delegate.  Call cost is identical to a direct property access.
+    /// Returns the partition-key value for <paramref name="item"/> using the pre-compiled delegate.
+    /// Throws <see cref="CosmosConfigurationException"/> when the DAO type does not expose the
+    /// partition key property — indicates a write service was used with a read-only model.
     /// </summary>
     private string GetPartitionKeyValue(T item)
     {
+        if (_getPartitionKey is null)
+            throw new CosmosConfigurationException(
+                $"'{typeof(T).Name}' does not have a property that maps to partition key " +
+                $"'{_partitionKeyProperty}'. Write operations require the partition key property. " +
+                $"Add the property to the DAO or use [JsonPropertyName(\"{_partitionKeyProperty}\")] " +
+                $"on the matching field. If this model is read-only, use ICosmosDataReadService instead.");
+
         var value = _getPartitionKey(item);
         if (value is null)
             throw new InvalidOperationException(
@@ -933,29 +941,37 @@ public class CosmosRepository<T> : ICosmosRepository<T> where T : class, ICosmos
     }
 
     /// <summary>
-    /// Builds a compiled <see cref="Func{T, String}"/> that reads the named property from
-    /// an instance of <typeparamref name="T"/> without reflection overhead at call time.
+    /// Builds a compiled <see cref="Func{T, String}"/> that reads the partition-key property
+    /// from an instance of <typeparamref name="T"/> without reflection overhead at call time.
+    /// Returns <c>null</c> when the property cannot be resolved — valid for read-only models.
     /// </summary>
     /// <remarks>
-    /// The expression tree produced is equivalent to: <c>item => item.{propertyName}.ToString()</c>
-    ///
-    /// Step-by-step:
-    ///   1. <c>Expression.Parameter</c> declares the lambda's input parameter ("item").
-    ///   2. <c>Expression.Property</c> emits a member-access node for the named property.
-    ///      This validates that the property exists on T and throws here (construction time)
-    ///      rather than on the first write if the configuration is wrong.
-    ///   3. <c>Expression.Call</c> wraps the property access in a ToString() call so
-    ///      the lambda always returns string regardless of the underlying property type
-    ///      (string, Guid, int, etc.).
-    ///   4. <c>Expression.Lambda&lt;TDelegate&gt;</c> packages nodes 1–3 into a typed lambda.
-    ///   5. <c>.Compile()</c> JIT-compiles the expression tree into a real CLR delegate.
-    ///      This is the only expensive step and happens exactly once per repository instance.
+    /// Resolution is a two-step lookup (done once at construction):
+    ///   1. Try <paramref name="propertyName"/> as a C# property name directly.
+    ///   2. If not found, scan for a property decorated with
+    ///      <c>[JsonPropertyName("<paramref name="propertyName"/>")]</c>.
+    ///      This supports configurations where the Cosmos JSON field name (e.g. "btLockboxNumber")
+    ///      differs from the C# property name (e.g. "Lockbox").
+    /// If neither lookup succeeds, returns <c>null</c>; no exception is thrown here so that
+    /// read-only models can register and query without a partition key property on the DAO.
     /// </remarks>
-    private static Func<T, string> BuildPartitionKeyAccessor(string propertyName)
+    private static Func<T, string>? BuildPartitionKeyAccessor(string propertyName)
     {
-        var param    = Expression.Parameter(typeof(T), "item");
-        var property = Expression.Property(param, propertyName); // throws ArgumentException if not found
-        var toString = Expression.Call(property, nameof(object.ToString), Type.EmptyTypes);
+        var type = typeof(T);
+
+        // Step 1: exact C# property name
+        var prop = type.GetProperty(propertyName);
+
+        // Step 2: scan for [JsonPropertyName] attribute whose value matches
+        prop ??= type.GetProperties()
+            .FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name == propertyName);
+
+        if (prop is null)
+            return null;
+
+        var param    = Expression.Parameter(type, "item");
+        var access   = Expression.Property(param, prop);
+        var toString = Expression.Call(access, nameof(object.ToString), Type.EmptyTypes);
         return Expression.Lambda<Func<T, string>>(toString, param).Compile();
     }
 

--- a/src/CosmoBase.Core/Validation/CosmosValidator.cs
+++ b/src/CosmoBase.Core/Validation/CosmosValidator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using CosmoBase.Abstractions.Exceptions;
 using CosmoBase.Abstractions.Filters;
 using CosmoBase.Abstractions.Interfaces;
@@ -17,35 +19,37 @@ public class CosmosValidator<T> : ICosmosValidator<T> where T : class, ICosmosDa
     public void ValidateModelConfiguration(string partitionKeyProperty)
     {
         var modelType = typeof(T);
-        
-        // 1. Validate partition key property exists
-        var partitionKeyProp = modelType.GetProperty(partitionKeyProperty);
-        if (partitionKeyProp == null)
-        {
-            var availableProps = string.Join(", ", modelType.GetProperties().Select(p => p.Name));
-            var message = $"Partition key property '{partitionKeyProperty}' not found on type '{modelType.Name}'. " +
-                         $"Available properties: {availableProps}";
-            throw new CosmosConfigurationException(message);
-        }
 
-        // 2. Validate partition key property type is supported
-        if (!CosmosValidationConstants.SupportedPartitionKeyTypes.Contains(partitionKeyProp.PropertyType))
-        {
-            var supportedTypeNames = CosmosValidationConstants.SupportedPartitionKeyTypes.Select(t => t.Name);
-            var message = $"Partition key property '{partitionKeyProperty}' on type '{modelType.Name}' " +
-                         $"has unsupported type '{partitionKeyProp.PropertyType.Name}'. " +
-                         $"Supported types: {string.Join(", ", supportedTypeNames)}";
-            throw new CosmosConfigurationException(message);
-        }
+        // Resolve the partition key property via two-step lookup:
+        //   1. C# property name
+        //   2. [JsonPropertyName] attribute value (supports JSON-name config)
+        // Property is optional — read-only models may omit it entirely.
+        var partitionKeyProp = modelType.GetProperty(partitionKeyProperty)
+            ?? modelType.GetProperties()
+                .FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name == partitionKeyProperty);
 
-        // 3. Validate partition key property is readable
-        if (!partitionKeyProp.CanRead)
+        if (partitionKeyProp != null)
         {
-            var message = $"Partition key property '{partitionKeyProperty}' on type '{modelType.Name}' is not readable";
-            throw new CosmosConfigurationException(message);
-        }
+            // Validate type is supported when property is present
+            if (!CosmosValidationConstants.SupportedPartitionKeyTypes.Contains(partitionKeyProp.PropertyType))
+            {
+                var supportedTypeNames = CosmosValidationConstants.SupportedPartitionKeyTypes.Select(t => t.Name);
+                var message = $"Partition key property '{partitionKeyProperty}' on type '{modelType.Name}' " +
+                             $"has unsupported type '{partitionKeyProp.PropertyType.Name}'. " +
+                             $"Supported types: {string.Join(", ", supportedTypeNames)}";
+                throw new CosmosConfigurationException(message);
+            }
 
-        // 4. Validate required ICosmosDataModel properties exist
+            if (!partitionKeyProp.CanRead)
+            {
+                var message = $"Partition key property '{partitionKeyProperty}' on type '{modelType.Name}' is not readable";
+                throw new CosmosConfigurationException(message);
+            }
+        }
+        // No throw when property is absent — read-only models are valid without it.
+        // Write operations enforce presence via CosmosDataWriteService and GetPartitionKeyValue.
+
+        // Always validate required ICosmosDataModel properties
         ValidateRequiredProperties(modelType);
     }
 
@@ -306,15 +310,27 @@ public class CosmosValidator<T> : ICosmosValidator<T> where T : class, ICosmosDa
 
     /// <summary>
     /// Reads the partition key value from an item using reflection.
+    /// Resolves via C# property name first, then <see cref="JsonPropertyNameAttribute"/> scan.
     /// </summary>
     private static string GetPartitionKeyValue(T item, string partitionKeyProperty)
     {
-        var prop = typeof(T).GetProperty(partitionKeyProperty)
-                   ?? throw new InvalidOperationException(
-                       $"Partition-key property '{partitionKeyProperty}' not found on type '{typeof(T).Name}'");
+        var type = typeof(T);
+
+        // Step 1: C# property name
+        var prop = type.GetProperty(partitionKeyProperty);
+
+        // Step 2: [JsonPropertyName] attribute match
+        prop ??= type.GetProperties()
+            .FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name == partitionKeyProperty);
+
+        if (prop is null)
+            throw new InvalidOperationException(
+                $"Partition-key property '{partitionKeyProperty}' not found on type '{type.Name}' " +
+                $"by C# name or [JsonPropertyName] attribute");
+
         var raw = prop.GetValue(item)
                   ?? throw new InvalidOperationException(
-                      $"Partition-key value for '{partitionKeyProperty}' on '{typeof(T).Name}' was null");
+                      $"Partition-key value for '{partitionKeyProperty}' on '{type.Name}' was null");
         return raw.ToString()!;
     }
 

--- a/src/CosmoBase.DataServices/CosmosDataWriteService.cs
+++ b/src/CosmoBase.DataServices/CosmosDataWriteService.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Text.Json.Serialization;
 using CosmoBase.Abstractions.Enums;
 using CosmoBase.Abstractions.Exceptions;
 using CosmoBase.Abstractions.Filters;
@@ -44,6 +46,26 @@ public class CosmosDataWriteService<TDto, TDao> : ICosmosDataWriteService<TDto, 
         _cosmosRepository = cosmosRepository ?? throw new ArgumentNullException(nameof(cosmosRepository));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _logger = logger;
+
+        // Fail at service construction — not at the first write call — so misconfigured
+        // write models are caught as early as possible (first DI scope resolution).
+        EnsurePartitionKeyProperty(cosmosRepository.PartitionKeyProperty);
+    }
+
+    private static void EnsurePartitionKeyProperty(string partitionKeyProperty)
+    {
+        var type = typeof(TDao);
+        var found = type.GetProperty(partitionKeyProperty) != null
+            || type.GetProperties().Any(p =>
+                p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name == partitionKeyProperty);
+
+        if (!found)
+            throw new CosmosConfigurationException(
+                $"'{type.Name}' is registered as a write model but has no property that maps to " +
+                $"partition key '{partitionKeyProperty}'. " +
+                $"Add the property to the DAO, or annotate the matching field with " +
+                $"[JsonPropertyName(\"{partitionKeyProperty}\")]. " +
+                $"If this model is read-only, inject ICosmosDataReadService instead.");
     }
 
     #region Single Document Operations


### PR DESCRIPTION
- Read-only DAO models no longer require the partition key property at registration. BuildPartitionKeyAccessor returns null when the property is absent; write operations throw CosmosConfigurationException with a clear message if called on such a model.

- PartitionKey config now accepts the Cosmos JSON field name (e.g. "btLockboxNumber") in addition to the C# property name. Both repository accessor and validator use a two-step lookup: C# name first, then [JsonPropertyName] attribute scan.

- Added ICosmosRepository<T>.PartitionKeyProperty to expose the configured name. CosmosDataWriteService validates at construction time that the DAO exposes the partition key property, preserving fail-fast behaviour for write models.

- Updated ValidateModelConfiguration to treat the partition key property as optional; type/readability checks still fire when the property is present.

- CHANGELOG, README pitfall notes updated for v1.0.2.